### PR TITLE
Pin workspace pnpm version and align engines.node with CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nuxt-compose-icons-root",
   "author": "",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "changeset": "changeset",
     "changeset:publish": "changeset publish",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -86,7 +86,7 @@
   },
   "homepage": "https://nuxt-icons.use-compose.com",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "sideEffects": false,
   "main": "./dist/module.mjs",


### PR DESCRIPTION
Add a packageManager pin to the workspace root so Corepack resolves pnpm >=10.26 there too, matching what allowBuilds in pnpm-workspace.yaml requires. Also bump packages/nuxt engines.node to
>=22.0.0 to match the Node versions actually covered by CI now that
Node 20 was dropped from the lint/test matrices for pnpm 11 compatibility.


Claude-Session: https://claude.ai/code/session_01PgzYH41qq7utTyUQ7N7duP