### PR TITLE
ci: add CodeQL static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+# CodeQL static analysis. Results appear under the repository's Security tab.
+#
+# Both analysed languages use `build-mode: none`, so no build steps are needed.
+# If a compiled language is ever added to the matrix, set its build mode to
+# "manual" and add the build commands as a step before the analyze step. See
+# https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+name: 'CodeQL Advanced'
+
+on:
+  push:
+    branches: ['dev']
+  pull_request:
+    branches: ['dev']
+  schedule:
+    - cron: '37 4 * * 0' # Every Sunday at 04:37 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # required to upload analysis results
+      packages: read # required to fetch internal or private CodeQL packs
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Optional: broaden coverage with `security-extended` or
+          # `security-and-quality` at the cost of more findings.
+          # queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
Adds GitHub's CodeQL Advanced workflow, analysing `javascript-typescript` and `actions` on pushes/PRs to `dev` plus a weekly schedule (Sundays 04:37 UTC). Results land under the repository's Security tab.

Verified before adding:
- Code scanning **default setup is `not-configured`**, so an advanced workflow won't conflict with it.
- Repo is public, so CodeQL is free.
- `actions/checkout@v7` and `github/codeql-action@v4` are both current tags.

Two edits vs. GitHub's generated starter:
- Dropped the `Run manual build steps` step — both languages use `build-mode: none`, so it can never run, and its `exit 1` is misleading noise. Rationale kept as a header comment for whenever a compiled language is added.
- Simplified `runs-on` — the `swift`/`macos-latest` ternary is dead with no `swift` in the matrix.

## Test plan
- [ ] CodeQL jobs run and pass on this PR
- [ ] Results appear under Security → Code scanning